### PR TITLE
Update license to reference prior work by Mike Reust

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 MIT License
 
+Copyright (c) 2016-2018 Mike Reust
 Copyright (c) 2020 Thomas Harold
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Portions of this code were originally published as MIT
by Mike Reust with a copyright notice of 2016.  Since
there are commits in 2018, I have taken the liberty to
list the years as 2016-2018.

https://github.com/reustmd/DataAnnotationsValidatorRecursive