### PR TITLE
Package updates in the test project

### DIFF
--- a/test/RecursiveDataAnnotationsValidation.Tests/RecursiveDataAnnotationsValidation.Tests.csproj
+++ b/test/RecursiveDataAnnotationsValidation.Tests/RecursiveDataAnnotationsValidation.Tests.csproj
@@ -11,13 +11,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
The test project does use Newtonsoft.Json v9 which is vulnerable per
https://github.com/advisories/GHSA-5crp-9r3c-p9vr but the main
project does not have any dependency on outdated packages.