### PR TITLE
Add more complicated Enumerable w/ Enumerable tests

### DIFF
--- a/test/RecursiveDataAnnotationsValidation.Tests/Attributes/EnumerableStringNotNullOrWhitespaceAttribute.cs
+++ b/test/RecursiveDataAnnotationsValidation.Tests/Attributes/EnumerableStringNotNullOrWhitespaceAttribute.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+
+namespace RecursiveDataAnnotationsValidation.Tests.Attributes;
+
+/// <summary>Examine each element in an IEnumerable of string and return false (not valid) if
+/// any of the string values are null/whitespace.  It makes no attempt to return the
+/// index number of the invalid entry; it only reports back a generic error for
+/// the IEnumerable of string property.
+/// </summary>
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property)]
+public class EnumerableStringNotNullOrWhitespaceAttribute : ValidationAttribute
+{
+    public EnumerableStringNotNullOrWhitespaceAttribute()
+    {
+        ErrorMessage = "Found elements that are null or whitespace.";
+    }
+    
+    public override bool IsValid(object value)
+    {
+        if (value is not IEnumerable<string> enumerableStrings) return true;
+
+        return !enumerableStrings.Any(x => string.IsNullOrWhiteSpace(x));
+    }
+}

--- a/test/RecursiveDataAnnotationsValidation.Tests/EnumerableExampleTests.cs
+++ b/test/RecursiveDataAnnotationsValidation.Tests/EnumerableExampleTests.cs
@@ -20,6 +20,7 @@ namespace RecursiveDataAnnotationsValidation.Tests
                 Items = new List<ItemExample>(),
                 ItemsList = new List<ItemExample>(),
                 ItemsCollection = new List<ItemExample>(),
+                ItemWithListExamples = new List<ItemWithListExample>(),
             };
 
             var validationResults = new List<ValidationResult>();
@@ -110,7 +111,19 @@ namespace RecursiveDataAnnotationsValidation.Tests
                             ExampleEnumD = ExampleEnum.ValueA
                         }
                     }
-                }
+                },
+                ItemWithListExamples = new List<ItemWithListExample>
+                {
+                    new ItemWithListExample
+                    {
+                        ItemWithListName = "ItemList 0L",
+                        Claims = new List<string>
+                        {
+                            "Claim 0L-1",
+                            "Claim 0L-2",
+                        },
+                    },
+                },
             };
 
             var validationResults = new List<ValidationResult>();
@@ -284,7 +297,46 @@ namespace RecursiveDataAnnotationsValidation.Tests
                         ExampleEnumD = ExampleEnum.ValueA
                     }
                 },
-            }
+            },
+            ItemWithListExamples = new List<ItemWithListExample>
+            {
+                new ItemWithListExample
+                {
+                    ItemWithListName = null,
+                    Claims = new List<string>
+                    {
+                        null,
+                        "ItemList Claim 0L-1L",
+                    },
+                },
+                new ItemWithListExample
+                {
+                    ItemWithListName = "ItemList 1L",
+                    Claims = new List<string>
+                    {
+                        "ItemList Claim 1L-0L",
+                        " ", // whitespace
+                    },
+                },
+                new ItemWithListExample
+                {
+                    ItemWithListName = "ItemList 2L",
+                    Claims = null
+                },
+                new ItemWithListExample
+                {
+                    ItemWithListName = "ItemList 3L",
+                    Claims = new List<string>
+                    {
+                        "ItemList Claim 3L-0L",
+                        "ItemList Claim 3L-1L",
+                        "ItemList Claim 3L-2L",
+                        "ItemList Claim 3L-3L",
+                        "ItemList Claim 3L-4L",
+                        "ItemList Claim 3L-5L",
+                    },
+                },
+            },
         };
         
         [Theory]
@@ -298,6 +350,17 @@ namespace RecursiveDataAnnotationsValidation.Tests
         [InlineData("ItemsCollection[3].SimpleA.IntegerA")]
         [InlineData("ItemsCollection[3].SimpleA.StringB")]
         [InlineData("ItemsList[1].SimpleA.ExampleEnumD")]
+        [InlineData("ItemWithListExamples[0].ItemWithListName")]
+        // It would be nice if these would indicate which element in the IEnumerable was not valid.
+        // That's not easy / almost impossible to do with simple IEnumerable<T> like "string".
+        // There might be an ValidationAttribute derived class that does it?
+        // It may be out of scope for the RecursiveDataAnnotationsValidation project.
+        // It might be possible to report on the FIRST failure in the IEnumerable<T> with the index,
+        // but that would be the responsibility of whatever inherits from ValidationAttribute.
+        [InlineData("ItemWithListExamples[0].Claims")]
+        [InlineData("ItemWithListExamples[1].Claims")]
+        // ^---- future would output "ItemWithListExamples[x].Claims[y]" for the specific element
+        [InlineData("ItemWithListExamples[2].Claims")]
         public void Multiple_failures_contains_expected_memberName(string expectedMemberName)
         {
             var validationResults = new List<ValidationResult>();

--- a/test/RecursiveDataAnnotationsValidation.Tests/TestModels/EnumerableExample.cs
+++ b/test/RecursiveDataAnnotationsValidation.Tests/TestModels/EnumerableExample.cs
@@ -20,5 +20,8 @@ namespace RecursiveDataAnnotationsValidation.Tests.TestModels
         
         [Required]
         public List<ItemExample> ItemsCollection { get; set; }
+        
+        [Required]
+        public List<ItemWithListExample> ItemWithListExamples { get; set; }
     }
 }

--- a/test/RecursiveDataAnnotationsValidation.Tests/TestModels/ItemWithListExample.cs
+++ b/test/RecursiveDataAnnotationsValidation.Tests/TestModels/ItemWithListExample.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using RecursiveDataAnnotationsValidation.Tests.Attributes;
+
+namespace RecursiveDataAnnotationsValidation.Tests.TestModels
+{
+    public class ItemWithListExample
+    {
+        [Required]
+        public string ItemWithListName { get; set; }
+        
+        [Required]
+        [EnumerableStringNotNullOrWhitespace]
+        public List<string> Claims { get; set; }
+    }
+}


### PR DESCRIPTION
Add a test which has a List which contains elements which also have a List of string.

From what I can tell, there's no way for a ValidationAttribute validator to report back on all of the elements that failed validation within a simple `IEnumerable<string>` list.  

At best, you might be able to write a ValidationAttribute validator which reports back on the index of the first failure within the list.