### PR TITLE
Fix README inclusion in NuGet package

### DIFF
--- a/src/RecursiveDataAnnotationsValidation/RecursiveDataAnnotationsValidation.csproj
+++ b/src/RecursiveDataAnnotationsValidation/RecursiveDataAnnotationsValidation.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="README.md" Pack="true" PackagePath="README.md" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The RecursiveDataAnnotationsValidation NuGet package was showing a 'missing README' warning on nuget.org. While the project contained a README.md file, it wasn't being properly included in the NuGet package due to incorrect PackagePath configuration.

This change updates the project file to explicitly specify the README.md file should be packaged at 'README.md' path, which ensures it appears correctly in NuGet packages and resolves the warning on nuget.org.

This follows Microsoft's recommended approach for including README files in .NET NuGet packages, ensuring that users will see proper documentation when browsing the package on nuget.org.